### PR TITLE
release: @mainset/react@0.1.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/react",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Set of UI React elements, components, hooks, etc for creating user interfaces, based on the mainset design system.",
   "repository": "https://github.com/mainset/ui-stack/tree/main/packages/react",
   "author": "Yevhen Uzhva <yevhen.uzhva@gmail.com>",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/ui-core",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Basic SCSS, TypeScript and JS configurations for mainset UI",
   "keywords": [],
   "author": "Yevhen Uzhva <yevhen.uzhva@gmail.com>",


### PR DESCRIPTION
- Distinguish CSS styles and TS types into a standalone `ui-core` package with primitives that could be used to build on top libraries like `@mainset/react` etc.
- rewrite all available components that are used in `hrifi` project