### PR TITLE
release: @mainset/react@0.1.1

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mainset/react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Set of UI React elements, components, hooks, etc for creating user interfaces, based on the mainset design system.",
   "repository": "https://github.com/mainset/ui-stack/tree/main/packages/react",
   "author": "Yevhen Uzhva <yevhen.uzhva@gmail.com>",


### PR DESCRIPTION
Publish `@mainset/ui-core` package to npm registry and make it a required dependency, so it will be installed in the final app without overhead.

[fix: publish ui-core package to npm registry](https://github.com/mainset/ui-stack/commit/b6c49ad57abc6b546c040af60f587d7ce8a8ebe7)